### PR TITLE
CD-144452 Added option embed image without extension canvas

### DIFF
--- a/options.go
+++ b/options.go
@@ -188,40 +188,41 @@ type Sharpen struct {
 
 // Options represents the supported image transformation options.
 type Options struct {
-	Height         int
-	Width          int
-	AreaHeight     int
-	AreaWidth      int
-	Top            int
-	Left           int
-	Quality        int
-	Compression    int
-	Zoom           int
-	Crop           bool
-	SmartCrop      bool // Deprecated, use: bimg.Options.Gravity = bimg.GravitySmart
-	Enlarge        bool
-	Embed          bool
-	Flip           bool
-	Flop           bool
-	Force          bool
-	NoAutoRotate   bool
-	NoProfile      bool
-	Interlace      bool
-	StripMetadata  bool
-	Trim           bool
-	Lossless       bool
-	Extend         Extend
-	Rotate         Angle
-	Background     Color
-	Gravity        Gravity
-	Watermark      Watermark
-	WatermarkImage WatermarkImage
-	Type           ImageType
-	Interpolator   Interpolator
-	Interpretation Interpretation
-	GaussianBlur   GaussianBlur
-	Sharpen        Sharpen
-	Threshold      float64
-	OutputICC      string
-	NumOfPages     int
+	Height                int
+	Width                 int
+	AreaHeight            int
+	AreaWidth             int
+	Top                   int
+	Left                  int
+	Quality               int
+	Compression           int
+	Zoom                  int
+	Crop                  bool
+	SmartCrop             bool // Deprecated, use: bimg.Options.Gravity = bimg.GravitySmart
+	Enlarge               bool
+	Embed                 bool
+	EmbedWithoutExtension bool
+	Flip                  bool
+	Flop                  bool
+	Force                 bool
+	NoAutoRotate          bool
+	NoProfile             bool
+	Interlace             bool
+	StripMetadata         bool
+	Trim                  bool
+	Lossless              bool
+	Extend                Extend
+	Rotate                Angle
+	Background            Color
+	Gravity               Gravity
+	Watermark             Watermark
+	WatermarkImage        WatermarkImage
+	Type                  ImageType
+	Interpolator          Interpolator
+	Interpretation        Interpretation
+	GaussianBlur          GaussianBlur
+	Sharpen               Sharpen
+	Threshold             float64
+	OutputICC             string
+	NumOfPages            int
 }

--- a/resizer.go
+++ b/resizer.go
@@ -265,6 +265,13 @@ func extractOrEmbedImage(image *C.VipsImage, o Options) (*C.VipsImage, error) {
 		left, top = int(math.Max(float64(left), 0)), int(math.Max(float64(top), 0))
 		image, err = vipsExtract(image, left, top, width, height)
 		break
+	// Order of case o.EmbedWithoutExtension and o.Embed is important
+	// For EmbedWithoutExtension to work both the options are set to true
+	// EmbedWithoutExtension embeds the image without the background extension to maintain the aspect ratio
+	case o.EmbedWithoutExtension:
+		image, err = vipsEmbed(image, 0, 0, inWidth, inHeight, o.Extend, o.Background)
+		break
+	// Embed embeds the image with the background extension to maintain the aspect ratio
 	case o.Embed:
 		left, top := (o.Width-inWidth)/2, (o.Height-inHeight)/2
 		image, err = vipsEmbed(image, left, top, o.Width, o.Height, o.Extend, o.Background)


### PR DESCRIPTION
Main ticket: https://coupadev.atlassian.net/browse/CD-144452
Propagation ticket: https://coupadev.atlassian.net/browse/CD-144454

Please review:
- [ ] @priyankatapar 
- [ ] @revathi-murali 
- [x] @saghaulor 

Summary Of change:
Change the approach to maintain the aspect ratio and remove black extension from the background while creating thumbnail. Added bimg option EmbedWithoutExtension. Previous approach was not working with float values.