### PR TITLE
Cd 138824 removed support for # of pages selection for gif

### DIFF
--- a/vips.h
+++ b/vips.h
@@ -366,7 +366,7 @@ vips_init_image (void *buf, size_t len, int imageType, VipsImage **out, Options 
 #if (VIPS_MAJOR_VERSION >= 8)
 #if (VIPS_MINOR_VERSION >= 3)
 	} else if (imageType == GIF) {
-		code = vips_gifload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, "n", opts->NumOfPages, NULL);
+		code = vips_gifload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, NULL);
 	} else if (imageType == PDF) {
 		code = vips_pdfload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, "n", opts->NumOfPages, NULL);
 	} else if (imageType == SVG) {


### PR DESCRIPTION
https://coupadev.atlassian.net/browse/CD-138824
https://coupadev.atlassian.net/browse/CD-138825

While converting GIF to PNG only first frame will be converted. We will not include all the frames in the output PNG. Initially we implemented this but removing it now after evaluating the use cases.  

Please review:
- [ ] @revathi-murali 