### PR TITLE
CD-146690 Added support for passing density for pdf

### DIFF
--- a/image.go
+++ b/image.go
@@ -173,8 +173,8 @@ func (i *Image) Convert(t ImageType) ([]byte, error) {
 }
 
 // ConvertPage converts the specified page from a multi-page image to another format.
-func (i *Image) ConvertPages(t ImageType, n int) ([]byte, error) {
-	options := Options{Type: t, NumOfPages: n}
+func (i *Image) ConvertPages(t ImageType, n int, d float64) ([]byte, error) {
+	options := Options{Type: t, NumOfPages: n, Density: d}
 	return i.Process(options)
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -362,7 +362,7 @@ func TestImageConvert(t *testing.T) {
 
 func TestConvertPage(t *testing.T) {
 	i := initImage("test.gif")
-	buf, err := i.ConvertPages(JPEG, 7)
+	buf, err := i.ConvertPages(JPEG, 7, 0)
 	if err != nil {
 		t.Errorf("Cannot process the image: %#v", err)
 	}
@@ -370,7 +370,7 @@ func TestConvertPage(t *testing.T) {
 	WriteToFileAndCleanup(t, "testdata/test_convert_multipage_gif.jpg", buf)
 
 	i = initImage("test.tiff")
-	buf, err = i.ConvertPages(JPEG, 0)
+	buf, err = i.ConvertPages(JPEG, 0, 0)
 	if err != nil {
 		t.Errorf("Cannot process the image: %#v", err)
 	}
@@ -379,7 +379,7 @@ func TestConvertPage(t *testing.T) {
 
 	if VipsMajorVersion >= 8 && VipsMinorVersion > 2 {
 		i := initImage("test2.pdf")
-		buf, err := i.ConvertPages(JPEG, 0)
+		buf, err := i.ConvertPages(JPEG, 0, 50)
 		if err != nil {
 			t.Errorf("Cannot process the image: %#v", err)
 		}

--- a/options.go
+++ b/options.go
@@ -225,4 +225,5 @@ type Options struct {
 	Threshold             float64
 	OutputICC             string
 	NumOfPages            int
+	Density               float64
 }

--- a/vips.go
+++ b/vips.go
@@ -78,6 +78,7 @@ type vipsWatermarkTextOptions struct {
 
 type vipsLoadOptions struct {
 	NumOfPages C.int
+	Density    C.double
 }
 
 func init() {
@@ -317,7 +318,7 @@ func vipsReadWithOptions(buf []byte, o Options) (*C.VipsImage, ImageType, error)
 		o.NumOfPages = -1
 	}
 
-	opts := vipsLoadOptions{NumOfPages: C.int(o.NumOfPages)}
+	opts := vipsLoadOptions{NumOfPages: C.int(o.NumOfPages), Density: C.double(o.Density)}
 	err := C.vips_init_image(imageBuf, length, C.int(imageType), &image, (*C.Options)(unsafe.Pointer(&opts)))
 	if err != 0 {
 		return nil, UNKNOWN, catchVipsError()

--- a/vips.h
+++ b/vips.h
@@ -57,6 +57,7 @@ typedef struct {
 
 typedef struct {
   int NumOfPages;
+  double Density;
 } Options;
 
 static unsigned long
@@ -368,7 +369,7 @@ vips_init_image (void *buf, size_t len, int imageType, VipsImage **out, Options 
 	} else if (imageType == GIF) {
 		code = vips_gifload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, NULL);
 	} else if (imageType == PDF) {
-		code = vips_pdfload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, "n", opts->NumOfPages, NULL);
+		code = vips_pdfload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, "n", opts->NumOfPages, "dpi", opts->Density, NULL);
 	} else if (imageType == SVG) {
 		code = vips_svgload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, NULL);
 #endif


### PR DESCRIPTION
https://coupadev.atlassian.net/browse/CD-146690
https://coupadev.atlassian.net/browse/CD-146693

Summary of change:
Added support to pass option "density" to vips_pdfload_buffer.

Please review:

- [x] @revathi-murali 
- [x] @priyankatapar 
- [x] @saghaulor 