### PR TITLE
CD-164162 Fix for huge tiff file with 100 pages when converting to png

### DIFF
--- a/join.go
+++ b/join.go
@@ -6,18 +6,71 @@ package bimg
 */
 import "C"
 
+import (
+	"errors"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+const PNGError = "vips2png: unable to write to buffer"
+
 func ImageJoin(imgArr []*Image, imageType ImageType) ([]byte, error) {
 	defer C.vips_thread_shutdown()
 
 	image, err := vipsArrayJoin(imgArr)
 	if err != nil {
+		log.Errorf("[ImageJoin] vipsArrayJoin err - %v", err)
 		return nil, err
 	}
-
+	imageCopy := image
 	buf, err := getImageBuffer(image, imageType)
 	if err != nil {
+		/*
+			`getImageBuffer` internally calls `vips_pngsave_bridge` which throws "vips2png: unable to write to buffer" when we try to save a PNG that has more (100) pages.
+			So when we get vips2png error, we write the vips image to a temp file and read the data from temp file. Directly writing to a temp file without calling `getImageBuffer` has
+			performance impacts and hence writing to temp file when PNGError is thrown from `getImageBuffer`.
+		*/
+		if strings.Contains(err.Error(), PNGError) {
+			return getImageBufferFromFile(imageCopy, imageType)
+		}
 		return nil, err
 	}
 
 	return buf, nil
+}
+
+// Write C.VipsImage to temp file and read the buffer from temp file.
+// This is called only when `getImageBuffer` throws `vips2png: unable to write to buffer` error.
+func getImageBufferFromFile(image *C.VipsImage, imageType ImageType) ([]byte, error) {
+	fileExt := getExtension(imageType)
+	if fileExt == "unknown" {
+		return nil, errors.New(fmt.Sprintf("[ImageJoin] Unknown extension for the imagetype %s", ImageTypeName(imageType)))
+	}
+
+	tmpFile, err := ioutil.TempFile("", "joined-img-*"+fileExt)
+	if err != nil {
+		log.Errorf("[ImageJoin] Error in initializing tmp file - %v", err)
+		return nil, err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	err = vipsWriteToFile(image, tmpFile.Name())
+	if err != nil {
+		log.Errorf("[ImageJoin] vipsWriteToFile error - %v", err)
+		return nil, err
+	}
+
+	return Read(tmpFile.Name())
+}
+
+func getExtension(imageType ImageType) string {
+	if imageType == PNG {
+		return ".png"
+	}
+
+	// Right now, `ImageJoin` function joins only PNG images.
+	return "unknown"
 }

--- a/vips.go
+++ b/vips.go
@@ -490,6 +490,15 @@ func vipsSave(image *C.VipsImage, o vipsSaveOptions) ([]byte, error) {
 	return buf, nil
 }
 
+func vipsWriteToFile(image *C.VipsImage, filename string) error {
+	err := C.vips_write_to_file_bridge(image, C.CString(filename))
+	if int(err) != 0 {
+		return catchVipsError()
+	}
+
+	return nil
+}
+
 func getImageBuffer(image *C.VipsImage, imageType ImageType) ([]byte, error) {
 	var ptr unsafe.Pointer
 

--- a/vips.h
+++ b/vips.h
@@ -581,3 +581,7 @@ vips_arrayjoin_bridge( VipsImage **in, VipsImage **out, int n) {
   return vips_arrayjoin(in, out, n, "across", 1, "background", vipsBackground,  NULL);
 }
 
+int
+vips_write_to_file_bridge( VipsImage *in, const char *name) {
+  return vips_image_write_to_file(in, name, NULL);
+}


### PR DESCRIPTION
## JIRA

[Main JIRA ticket](https://coupadev.atlassian.net/browse/CD-164162)

## Reviewers

- [ ] @tjackiw 
- [ ] @priyankatapar 
cc:  @sushmanivargi 

## Summary of Issue

`getImageBuffer` internally calls `vips_pngsave_buffer` which is unable to save the Png that is created after joining 100 pages - eg: `1207*15034` and hence it throws the error
`vips2png unable to write to buffer`

## Summary of change

Instead of calling `vips_pngsave_buffer`, writing the png image to write and then reading the buffer data from the file