### PR TITLE
CD-168822 Change 'vips_get_page_count' to use 'vips_image_get_n_pages' method of libvips v8.8.2

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -770,6 +770,6 @@ func VipsPDFPageCount(buf []byte) (int, error) {
 	if err != 0 {
 		return 0, catchVipsError()
 	}
-	pages := C.vips_get_page_count(image)
+	pages := C.vips_image_get_n_pages_bridge(image)
 	return int(pages), nil
 }

--- a/vips.h
+++ b/vips.h
@@ -592,19 +592,6 @@ vips_pdfload_buffer_bridge(void *buf, size_t len, VipsImage **out) {
 }
 
 int 
-vips_get_page_count(VipsImage *image) {
-  /* The below code is taken from `vips_image_get_n_pages` method of libvips v8.8.1 as this method is not exposed in v8.7.4.
-    Ref: https://github.com/libvips/libvips/blob/master/libvips/iofuncs/header.c#L824-#L834
-    Note: Remove the below code when libvips is upgraded to v8.8.1
-  */
-
-  int n_pages;
-
-  if( !vips_image_get_typeof( image, VIPS_META_N_PAGES ) ||
-    vips_image_get_int( image, VIPS_META_N_PAGES, &n_pages ) ||
-    n_pages < 2 || 
-    n_pages > 1000 )
-    n_pages = 1;
-
-  return( n_pages );
+vips_image_get_n_pages_bridge(VipsImage *image) {
+  return vips_image_get_n_pages(image);
 }


### PR DESCRIPTION
## JIRA

[Main JIRA Ticket](https://coupadev.atlassian.net/browse/CD-168822)

## Reviewers

- [ ] @priyankatapar 

## Summary of Change

Since libvips `v8.8.1` exposed the method to get the page count, removing the method implementation that was copied and directly calling the exposed method`vips_image_get_n_pages`